### PR TITLE
wrong variable used

### DIFF
--- a/ToolkitApi/Db2supp.php
+++ b/ToolkitApi/Db2supp.php
@@ -37,10 +37,12 @@ class db2supp
         }
 
         if ($options) {
+            $driver_options = $options['driver_options'] ?: [];
+
             if ((isset($options['persistent'])) && $options['persistent']) {
-                $conn = db2_pconnect($database, $user, $password, $options);
+                $conn = db2_pconnect($database, $user, $password, $driver_options);
             } else {
-                $conn = db2_connect($database, $user, $password, $options);
+                $conn = db2_connect($database, $user, $password, $driver_options);
             }
 
             if (is_resource($conn)) {


### PR DESCRIPTION
Missing driver_options can cause existing QSQSRVR jobs to switch between SQL naming and SYSTEM naming.